### PR TITLE
手続きを記述したスクリプトらを.productionとかによるリネームを行わない形にする

### DIFF
--- a/capcake/config/envfiles.yaml
+++ b/capcake/config/envfiles.yaml
@@ -7,7 +7,4 @@
 - "/app/config/database.php"
 - "/app/config/path.php"
 - "/app/webroot/robots.txt"
-- "/app/webroot/catalogCheck.php"
-- "/app/webroot/catalogConfirm.php"
-- "/app/webroot/catalogSave.php"
-- "/app/vendors/makehtaccess.php"
+- "/app/webroot/definitions.php"

--- a/capcake/config/envfiles.yaml
+++ b/capcake/config/envfiles.yaml
@@ -7,4 +7,3 @@
 - "/app/config/database.php"
 - "/app/config/path.php"
 - "/app/webroot/robots.txt"
-- "/app/webroot/definitions.php"


### PR DESCRIPTION
代わりにdefinitions.php[.production]を用意した

dacms側への変更が必要です
